### PR TITLE
Install `develop` 'extra'

### DIFF
--- a/deployment/deploy.py
+++ b/deployment/deploy.py
@@ -148,7 +148,7 @@ class Deployer:
         if not path.exists(path.join(self.project_root, 'setup.py')):
             self.run('pip install -e %s' % environ['DJCORE_GIT_REPO'])
             return
-        self.run('pip install -e %s' % self.project_root)
+        self.run('pip install -e %s[dev]' % self.project_root)
         requirements = path.join(self.project_root, 'requirements.txt')
         if path.exists(requirements):
             self.run('pip install --upgrade -r %s' % requirements)


### PR DESCRIPTION
When installing the project from a local path install the `develop`
'extra'.
Note: If the project does not supply a `develop` 'extra' then Pip still
installs the project and simply issues a warning that the `develop`
extra does not exist.